### PR TITLE
Remove the Lat and Lon reset

### DIFF
--- a/DataDisplayCYD.ino
+++ b/DataDisplayCYD.ino
@@ -2586,10 +2586,6 @@ void applyLocation() {
   setenv("TZ", posixTZ.c_str(), 1);
   tzset();
   
-  // RESET SOUŘADNIC - při vyberu ze seznamu musíme nechat fetchWeatherData() najít nové souřadnice
-  lat = 0.0;
-  lon = 0.0;
-  
   // Uložení do preferencí
   prefs.begin("sys", false);
   prefs.putString("city", selectedCity);


### PR DESCRIPTION
Setting lat and lon to 0 forces the Open Meteo API to search the city name which often returns the wrong city in the US (due to repeating city names and cities with small populations not being listed at all). There are two other APIs (Nominatim and IP-API) that return lat and lon. The weather API should be able to use the detected lat and lon for weather and be more accurate than having the weather API search the city name first and then using the lat and lon.

This should resolve a lot of issues and fix https://github.com/lachimalaif/DataDisplay-V1-instalator/issues/17